### PR TITLE
Allow digits of arbitrary length

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,6 @@ func Example() {
 	cfg := otp.Config{
 		Hash:   sha256.New, // default is sha1.New
 		Digits: 8,          // default is 6
-
 		// By default, time-based OTP generation uses time.Now.  You can plug in
 		// your own function to control how time steps are generated.
 		// This example uses a fixed time step so the output will be consistent.
@@ -38,6 +37,34 @@ func Example() {
 	// HOTP 1 86761489
 	//
 	// TOTP 86761489
+}
+
+func Example2() {
+	cfg := otp.Config{
+		Hash:    sha256.New, // default is sha1.New
+		Digits:  44,         // default is 6
+		NoTrunc: true,
+		// By default, time-based OTP generation uses time.Now.  You can plug in
+		// your own function to control how time steps are generated.
+		// This example uses a fixed time step so the output will be consistent.
+		TimeStep: fixedTime(1),
+	}
+
+	// 2FA setup tools often present the shared secret as a base32 string.
+	// ParseKey decodes this format.
+	if err := cfg.ParseKey("MFYH A3DF EB2G C4TU"); err != nil {
+		log.Fatalf("Parsing key: %v", err)
+	}
+
+	fmt.Println("HOTP", 0, cfg.HOTP(0))
+	fmt.Println("HOTP", 1, cfg.HOTP(1))
+	fmt.Println()
+	fmt.Println("TOTP", cfg.TOTP())
+	// Output:
+	// HOTP 0 EIiZPygQ3ArK2KObo3ILwr026IWbRkvS3zm/413yHPM=
+	// HOTP 1 6WKBpzdqZy4jIijvJhHK2LiGDjoFkaL8JUkW7ASd8po=
+	//
+	// TOTP 6WKBpzdqZy4jIijvJhHK2LiGDjoFkaL8JUkW7ASd8po=
 }
 
 func ExampleConfig_customFormat() {


### PR DESCRIPTION
Hi! I don't know if can be of any use outside of mine - but this changes slightly the OTP algorithm from the RFC spec example. The RFC actually speaks about truncation as a way to reduce the digits to be used by humans - but the full HMAC can be used for enhanced security, or portions of it (even more digits) as the RFC itself suggests. 

This change allows to skip truncation and uses base64 to encode the hash allowing to use the full hmac outside human interaction only, I guess probably this can be done in better ways, maybe using the Format function, however I didn't wanted to take that further and change much areas of the code without raising a PR to see if there is interest to pick up something like that first ( as I understand, it will drift away from the RFC 1:1 implementation, depending on the project goals might be wanted or not). 