### PR TITLE
Change the type signature of the Format callback.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,7 @@ package otp_test
 
 import (
 	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"log"
 
@@ -54,4 +55,22 @@ func ExampleConfig_customFormat() {
 	fmt.Println(cfg.TOTP())
 	// Output:
 	// FKNK3
+}
+
+func ExampleConfig_rawFormat() {
+	// The default formatting functions use the RFC 4226 truncation rules, but a
+	// custom formatter may do whatever it likes with the HMAC value.
+	// This example converts to base64.
+	cfg := otp.Config{
+		Digits: 10,
+		Format: func(hash []byte, nb int) string {
+			return base64.StdEncoding.EncodeToString(hash)[:nb]
+		},
+	}
+	if err := cfg.ParseKey("MNQWE YTBM5 SAYTS MVQXI"); err != nil {
+		log.Fatalf("Parsing key: %v", err)
+	}
+	fmt.Println(cfg.HOTP(17))
+	// Output:
+	// j0fLbXLh1Z
 }

--- a/internal_test.go
+++ b/internal_test.go
@@ -43,7 +43,7 @@ func (tc testCase) Run(t *testing.T, c Config, gen func(uint64) string) {
 	t.Helper()
 
 	hmac := c.hmac(tc.counter)
-	trunc := truncate(hmac)
+	trunc := Truncate(hmac)
 	hexDigest := hex.EncodeToString(hmac)
 	otp := gen(tc.counter)
 

--- a/otp.go
+++ b/otp.go
@@ -60,8 +60,8 @@ type Config struct {
 	Digits   int              // number of OTP digits (default 6)
 
 	// If set, this function is called with the counter hash to format a code of
-	// the specified width. By default, the code is truncated per RFC 4226
-	// (using the Truncate function) and formatted as decimal digits (0..9).
+	// the specified length. By default, the code is truncated per RFC 4226 and
+	// formatted as decimal digits (0..9).
 	//
 	// If Format returns a string of the wrong length, code generation panics.
 	Format func(hash []byte, length int) string

--- a/otp.go
+++ b/otp.go
@@ -166,7 +166,7 @@ func formatDecimal(hash []byte, width int) string {
 }
 
 // FormatAlphabet constructs a formatting function that truncates the counter
-// hash per RFC 4226 and assigned code digits using the letters of the given
+// hash per RFC 4226 and assigns code digits using the letters of the given
 // alphabet string.  Code digits are expanded from most to least significant.
 func FormatAlphabet(alphabet string) func([]byte, int) string {
 	if alphabet == "" {

--- a/otp.go
+++ b/otp.go
@@ -59,12 +59,12 @@ type Config struct {
 	Counter  uint64           // HOTP counter value
 	Digits   int              // number of OTP digits (default 6)
 
-	// If set, this function is called with the truncated counter hash to format
-	// a code of the specified width. By default, the code is formatted as
-	// decimal digits (0..9).
+	// If set, this function is called with the counter hash to format a code of
+	// the specified width. By default, the code is truncated per RFC 4226
+	// (using the Truncate function) and formatted as decimal digits (0..9).
 	//
 	// If Format returns a string of the wrong length, code generation panics.
-	Format func(v uint64, width int) string
+	Format func(hash []byte, length int) string
 }
 
 // ParseKey parses a base32 key using the top-level ParseKey function, and
@@ -92,7 +92,7 @@ func ParseKey(s string) ([]byte, error) {
 // HOTP returns the HOTP code for the specified counter value.
 func (c Config) HOTP(counter uint64) string {
 	nd := c.digits()
-	code := c.format(truncate(c.hmac(counter)), nd)
+	code := c.format(c.hmac(counter), nd)
 	if len(code) != nd {
 		panic(fmt.Sprintf("invalid code length: got %d, want %d", len(code), nd))
 	}
@@ -137,14 +137,16 @@ func (c Config) hmac(counter uint64) []byte {
 	return h.Sum(nil)
 }
 
-func (c Config) format(v uint64, nd int) string {
+func (c Config) format(v []byte, nd int) string {
 	if c.Format != nil {
 		return c.Format(v, nd)
 	}
-	return format(v, nd)
+	return formatDecimal(v, nd)
 }
 
-func truncate(digest []byte) uint64 {
+// Truncate truncates the specified digest using the algorithm from RFC 4226.
+// Only the low-order 31 bits of the value are populated; the rest are zero.
+func Truncate(digest []byte) uint64 {
 	offset := digest[len(digest)-1] & 0x0f
 	code := (uint64(digest[offset]&0x7f) << 24) |
 		(uint64(digest[offset+1]) << 16) |
@@ -153,24 +155,25 @@ func truncate(digest []byte) uint64 {
 	return code
 }
 
-func format(code uint64, width int) string {
+func formatDecimal(hash []byte, width int) string {
 	const padding = "00000000000000000000"
 
-	s := strconv.FormatUint(code, 10)
+	s := strconv.FormatUint(Truncate(hash), 10)
 	if len(s) < width {
 		s = padding[:width-len(s)] + s // left-pad with zeros
 	}
 	return s[len(s)-width:]
 }
 
-// FormatAlphabet constructs a formatting function that maps code digits to the
-// coresponding letters of the given alphabet string.  Code digits are expanded
-// from most to least significant.
-func FormatAlphabet(alphabet string) func(uint64, int) string {
+// FormatAlphabet constructs a formatting function that truncates the counter
+// hash per RFC 4226 and assigned code digits using the letters of the given
+// alphabet string.  Code digits are expanded from most to least significant.
+func FormatAlphabet(alphabet string) func([]byte, int) string {
 	if alphabet == "" {
 		panic("empty formatting alphabet")
 	}
-	return func(code uint64, width int) string {
+	return func(hmac []byte, width int) string {
+		code := Truncate(hmac)
 		w := uint64(len(alphabet))
 		out := make([]byte, width)
 		for i := width - 1; i >= 0; i-- {

--- a/otp_test.go
+++ b/otp_test.go
@@ -98,7 +98,8 @@ func TestGoogleAuthCompat(t *testing.T) {
 				Key: string(key),
 
 				// Map digits to corresponding letters 0=a, 1=b, etc.
-				Format: func(v uint64, nd int) string {
+				Format: func(hash []byte, nd int) string {
+					v := otp.Truncate(hash)
 					buf := make([]byte, nd)
 					for i := nd - 1; i >= 0; i-- {
 						buf[i] = byte(v%10) + byte('a')
@@ -124,7 +125,7 @@ func TestFormatBounds(t *testing.T) {
 		// Request 5 digits, but generate 8.
 		// This should cause code generation to panic.
 		Digits: 5,
-		Format: func(v uint64, nd int) string {
+		Format: func(_ []byte, nd int) string {
 			return "12345678" // N.B. not 5
 		},
 	}


### PR DESCRIPTION
A different approach to #1.

- Export the RFC 4226 truncation helper.
- Pass the unmodified hash to the formatter.
- Update the defaults to explicitly truncate.
- Update the existing tests.